### PR TITLE
Fix delete from cache method

### DIFF
--- a/Library/src/main/java/com/anupcowkur/reservoir/SimpleDiskCache.java
+++ b/Library/src/main/java/com/anupcowkur/reservoir/SimpleDiskCache.java
@@ -84,7 +84,7 @@ class SimpleDiskCache {
     }
 
     void delete(String key) throws IOException {
-        put(key, "", new HashMap<String, Serializable>());
+        diskLruCache.remove(toInternalKey(key));
     }
 
     private void put(String key, String value, Map<String, ? extends Serializable> annotations)


### PR DESCRIPTION
key is not removed from cache when delete function was called,
causing contains(key) to return true forever.