### PR TITLE
Added rx android as a provided dependency

### DIFF
--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile 'com.jakewharton:disklrucache:2.0.2'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'commons-io:commons-io:2.4'
-    compile 'io.reactivex:rxandroid:0.24.0'
+    provided 'io.reactivex:rxandroid:0.24.0'
 }
 
 publish {


### PR DESCRIPTION
Addresses #32 RxAndroid is added as a provided dependency and helps projects and upstream libraries, which do not use RxAndroid with the overall android method count (3555 for RxAndroid).

All espresso tests seem to pass here.